### PR TITLE
Use turtle icon for home link

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 
@@ -55,7 +56,9 @@ function AuthButtons() {
 export default function Navbar() {
   return (
     <header className="flex items-center justify-between pb-4">
-      <h1 className="text-2xl font-bold">Daniel&apos;s Game</h1>
+      <Link href="/" aria-label="Home">
+        <Image src="/chrome-turtle.svg" alt="" width={32} height={32} />
+      </Link>
       <nav className="flex items-center gap-4">
         <Link href="/">Home</Link>
         <Link href="/shop">Shop</Link>

--- a/public/chrome-turtle.svg
+++ b/public/chrome-turtle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m12 10 2 4v3a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-3a8 8 0 1 0-16 0v3a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-3l2-4h4Z" />
+  <path d="M4.82 7.9 8 10" />
+  <path d="M15.18 7.9 12 10" />
+  <path d="M16.93 10H20a2 2 0 0 1 0 4H2" />
+</svg>


### PR DESCRIPTION
## Summary
- Replace "Daniel's Game" heading with turtle icon linking to homepage
- Add chrome-style turtle SVG asset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68965ac06670832683dcbfc46c8f2e4b