### PR TITLE
feat: add settings dropdown

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -53,6 +53,30 @@ function AuthButtons() {
   );
 }
 
+function SettingsMenu() {
+  return (
+    <div className="dropdown dropdown-end">
+      <button tabIndex={0} aria-label="Settings" className="btn btn-ghost text-xl">
+        ⚙️
+      </button>
+      <ul
+        tabIndex={0}
+        className="dropdown-content menu mt-2 w-48 rounded-box bg-base-300 p-2 shadow"
+      >
+        <li>
+          <Link href="/admin">Admin</Link>
+        </li>
+        <li>
+          <ThemeToggle />
+        </li>
+        <li>
+          <AuthButtons />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
 export default function Navbar() {
   return (
     <header className="flex items-center justify-between pb-4">
@@ -63,9 +87,7 @@ export default function Navbar() {
         <Link href="/">Home</Link>
         <Link href="/shop">Shop</Link>
         <Link href="/inventory">My Inventory</Link>
-        <Link href="/admin">Admin</Link>
-        <ThemeToggle />
-        <AuthButtons />
+        <SettingsMenu />
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- consolidate admin, theme toggle, and auth actions into new settings dropdown
- apply background to the dropdown panel so menu items sit on a visible backdrop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68965e962e988326809243d0063da297