### PR TITLE
feat: enhance settings dropdown

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 
 function ThemeToggle() {
@@ -14,7 +14,7 @@ function ThemeToggle() {
     localStorage.setItem('theme', theme);
   }, [theme]);
   return (
-    <button className="toggle" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+    <button className="toggle w-full" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
       {theme === 'dark' ? '🌙 Dark' : '🌞 Light'}
     </button>
   );
@@ -45,11 +45,51 @@ function AuthButtons() {
   return (
     <>
       {user ? (
-        <button className="btn" onClick={signOut}>Sign out</button>
+        <button className="btn w-full" onClick={signOut}>Sign out</button>
       ) : (
-        <button className="btn" onClick={signIn}>Sign in with Discord</button>
+        <button className="btn w-full" onClick={signIn}>Sign in with Discord</button>
       )}
     </>
+  );
+}
+
+function SettingsMenu() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        aria-label="Settings"
+        className="text-xl"
+        onClick={() => setOpen((o) => !o)}
+      >
+        ⚙️
+      </button>
+      <div
+        className={`absolute right-0 mt-2 flex w-48 flex-col items-center gap-2 rounded bg-[var(--card)] p-2 text-center shadow transition duration-200 transform origin-top-right ${open ? 'scale-100 opacity-100' : 'pointer-events-none scale-95 opacity-0'}`}
+      >
+        <Link href="/admin" className="w-full">
+          Admin
+        </Link>
+        <ThemeToggle />
+        <AuthButtons />
+      </div>
+    </div>
   );
 }
 
@@ -63,9 +103,7 @@ export default function Navbar() {
         <Link href="/">Home</Link>
         <Link href="/shop">Shop</Link>
         <Link href="/inventory">My Inventory</Link>
-        <Link href="/admin">Admin</Link>
-        <ThemeToggle />
-        <AuthButtons />
+        <SettingsMenu />
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- center items in settings dropdown
- close dropdown when clicking outside
- animate menu opening and closing with smooth transitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Export encountered errors on following paths: /admin, /inventory, /leaderboard, /shop, /_not-found, /)*

------
https://chatgpt.com/codex/tasks/task_e_68965e962e988326809243d0063da297